### PR TITLE
Add jupyter notebook support to container

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ boto3 # for aws sdk
 matplotlib # required by spacepy but best to explicitly install it
 scipy # required by spacepy but best to explicitly install it
 spacepy # for cdf file support
+ipykernel # for jupyter notebook


### PR DESCRIPTION
This PR addresses this issue: #21 

It adds a package to the requirements file to allow for jupyter notebook support in the container.

**Before:**
![nb](https://user-images.githubusercontent.com/19628176/182134005-31d1196c-df00-46f3-bcc5-f8068e1ba157.png)

**After:**
![nb_test](https://user-images.githubusercontent.com/19628176/182133247-fdc454cd-91a2-4927-b67f-7e6aed50bc4d.png)

