### PR TITLE
Add `vscode` user to avoid permission issues in devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,11 +43,11 @@
 		"ms-python.python",
 		"ms-python.vscode-pylance",
 		"marklarah.pre-commit-vscode"
-	]
+	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	//"postCreateCommand": "bash -i -c 'pip3 install --user .[all]'",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	"remoteUser": "vscode"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,23 @@
 # Image: Ubuntu 20.04 Stable, Official Image from Canonical
 FROM public.ecr.aws/lts/ubuntu:20.04_stable
 
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # Add sudo support for the non-root user
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Set the default user
+USER $USERNAME
+
 # Performs updates and installs git, make, curl, python3.8, python3-pip, python3.8-dev and pylint packages
 # Line 13 is required by the spacepy Python package
 # Line >=14 installs cdflib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,6 @@
 # Image: Ubuntu 20.04 Stable, Official Image from Canonical
 FROM public.ecr.aws/lts/ubuntu:20.04_stable
 
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-# Create the user
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    #
-    # Add sudo support for the non-root user
-    && apt-get update \
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME
-
-# Set the default user
-USER $USERNAME
-
 # Performs updates and installs git, make, curl, python3.8, python3-pip, python3.8-dev and pylint packages
 # Line 13 is required by the spacepy Python package
 # Line >=14 installs cdflib
@@ -52,3 +35,21 @@ RUN  pip3 install --upgrade --force-reinstall setuptools==59.5.0
 
 # Install Python dependencies defined in requirements
 RUN  pip install -r requirements.txt
+
+# User to run the container
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # Add sudo support for the non-root user
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Set the default user
+USER $USERNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,3 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
-
-# Set the default user
-USER $USERNAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ boto3 # for aws sdk
 matplotlib # required by spacepy but best to explicitly install it
 scipy # required by spacepy but best to explicitly install it
 spacepy # for cdf file support
+ipykernel # for jupyter notebook


### PR DESCRIPTION
This PR helps address this issue: https://github.com/HERMES-SOC/hermes_eea/issues/6

This PR adds the `vscode` user as a user in the base container so it can be used as the `remote` user in the `devcontainer.json` configuration across the hermes package repos. (Each repo will get separate PR to fix `.devcontainer` config)

Also allows the `vscode` user access to the `sudo` command in case users want to try to install and try new software while developing.