### PR TITLE
Add CDF Update Workflow

### DIFF
--- a/.github/workflows/container-image-testing.yml
+++ b/.github/workflows/container-image-testing.yml
@@ -1,8 +1,12 @@
 name: Container Image Testing
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
 
 jobs:
 

--- a/.github/workflows/container-image-testing.yml
+++ b/.github/workflows/container-image-testing.yml
@@ -12,7 +12,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-22.04]
         python-version: [3.8]
 
     steps:

--- a/.github/workflows/update-cdf-library.yml
+++ b/.github/workflows/update-cdf-library.yml
@@ -88,7 +88,6 @@ jobs:
       
           # Assuming the extracted folder has the same name as the tar.gz file without the extension
           FOLDER_NAME="${FILENAME%-cdf.tar.gz}"
-          ls
           cd "$FOLDER_NAME"
           make OS=linux ENV=gnu all
           echo "CDF library built successfully."

--- a/.github/workflows/update-cdf-library.yml
+++ b/.github/workflows/update-cdf-library.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Download and extract CDF library
         if: steps.check_maintainer.outputs.is_maintainer != '' # Only run this step if the user is a maintainer
+        id : download_cdf
         run: |
           LATEST_VERSION="${{ steps.check_latest_version.outputs.latest_version }}"
           URL="${{ steps.check_latest_version.outputs.cdf_url }}"
@@ -76,12 +77,12 @@ jobs:
           tar zxvpf "$LATEST_VERSION" && rm "$LATEST_VERSION"
       
       - name: Install dependencies for Building CDF library
-        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.download_cdf.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
         run: sudo apt-get update && sudo apt-get -y install gfortran libncurses5-dev
 
       - name: Build CDF library
         id : build_cdf
-        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.download_cdf.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
         run: |
           FILENAME="${{ steps.check_latest_version.outputs.latest_version }}"
       
@@ -94,7 +95,7 @@ jobs:
           echo folder_name=$FOLDER_NAME >> $GITHUB_OUTPUT
 
       - name: Install CDF library
-        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.download_cdf.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
         run: |
             FOLDER_NAME="${{ steps.build_cdf.outputs.folder_name }}"
 
@@ -102,7 +103,7 @@ jobs:
             sudo make INSTALLDIR=./cdf install
 
       - name: Zip CDF Library in home
-        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.download_cdf.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
         run: |
               FOLDER_NAME="${{ steps.build_cdf.outputs.folder_name }}"
 
@@ -110,21 +111,21 @@ jobs:
               zip -r latest.zip cdf
     
       - name: Upload CDF Library to GitHub Artifacts
-        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.download_cdf.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
         uses: actions/upload-artifact@v2
         with:
           name: cdf
           path: "${{ steps.build_cdf.outputs.folder_name }}/latest.zip"
           
       - name: Configure AWS Credentials For GitHub Actions
-        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.download_cdf.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload CDF Library to S3
-        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.download_cdf.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
         run: |
           S3_BUCKET_NAME="${{ secrets.AWS_S3_BUCKET_NAME }}"
           FILENAME="${{ steps.build_cdf.outputs.folder_name }}/latest.zip"
@@ -135,7 +136,7 @@ jobs:
           aws s3 cp $FILENAME s3://$S3_BUCKET_NAME/cdf-binaries/$PARSED_LATEST_VERSION.zip
       
       - name: Create Pull Request
-        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.download_cdf.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
         uses: peter-evans/create-pull-request@v5.0.2
         with:
           title: 'Update CDF library to latest version (${{ steps.check_latest_version.outputs.latest_version }})'

--- a/.github/workflows/update-cdf-library.yml
+++ b/.github/workflows/update-cdf-library.yml
@@ -1,0 +1,143 @@
+name: Update CDF Library
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check if the user is a maintainer
+        id: check_maintainer
+        run: |
+          USERNAME="${{ github.actor }}"
+          REPO="${{ github.repository }}"
+          IS_MAINTAINER=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$REPO/collaborators" | jq -r ".[] | select(.login == \"$USERNAME\")")
+          echo is_maintainer=$IS_MAINTAINER >> $GITHUB_OUTPUT
+      
+      - uses: actions/checkout@v3 # Checkout the repository
+        if: steps.check_maintainer.outputs.is_maintainer != '' # Only run this step if the user is a maintainer
+        
+      - name: Check for the latest version of CDF library
+        id: check_latest_version
+        if: steps.check_maintainer.outputs.is_maintainer != '' # Only run this step if the user is a maintainer
+        run: |
+          URL="https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest/linux/"
+          FILENAME=$(curl -sL "$URL" | grep -oP 'href="[^"]*dist-cdf\.tar\.gz"' | awk -F '"' '!/\.md5$/ { print $2 }')
+
+          echo "Latest CDF version: $FILENAME"
+          echo cdf_url=$URL >> $GITHUB_OUTPUT
+          # Extract the line containing the CDF version
+          CDF_VERSION_LINE=$(grep -oP 'Version: cdf[^"]*' Dockerfile)
+
+          # Extract the version number from the line using awk and sed
+          CDF_VERSION=$(echo "$CDF_VERSION_LINE" | awk -F ': ' '{print $2}')
+
+          # Print the extracted CDF version
+          echo "CDF Version: $CDF_VERSION"
+          echo cdf_filename=$CDF_VERSION >> $GITHUB_OUTPUT
+          echo latest_version=$FILENAME >> $GITHUB_OUTPUT
+
+      - name: Download and extract CDF library
+        if: steps.check_maintainer.outputs.is_maintainer != '' # Only run this step if the user is a maintainer
+        run: |
+          LATEST_VERSION="${{ steps.check_latest_version.outputs.latest_version }}"
+          URL="${{ steps.check_latest_version.outputs.cdf_url }}"
+          FILENAME="${{ steps.check_latest_version.outputs.cdf_filename }}"
+          PARSED_LATEST_VERSION="${LATEST_VERSION%.tar.gz}"
+          # Check if the current version matches the latest version
+          if [ "$FILENAME" != "$PARSED_LATEST_VERSION" ]; then
+            echo "Updating CDF library version in Dockerfile..."
+            # Update version in the comment line
+            awk -v latest_ver="$PARSED_LATEST_VERSION" '/Version: cdf/{gsub(/Version: cdf[^"]*/, "Version: " latest_ver)} 1' Dockerfile > Dockerfile.updated
+            mv Dockerfile.updated Dockerfile
+            
+            # Update the download link
+            awk -v latest_ver="$PARSED_LATEST_VERSION" 'BEGIN{OFS=FS} /^RUN wget https:\/\/sdc-aws-support.s3.amazonaws.com\/cdf-binaries\/cdf[0-9._-]*-dist-cdf\.zip/{gsub(/cdf[0-9._-]*-dist-cdf\.zip/, latest_ver ".zip")} 1' Dockerfile > Dockerfile.updated
+            mv Dockerfile.updated Dockerfile
+            
+            # Update the unzip command
+            awk -v latest_ver="$PARSED_LATEST_VERSION" 'BEGIN{OFS=FS} /^RUN unzip cdf[0-9._-]*-dist-cdf\.zip/{gsub(/unzip cdf[0-9._-]*-dist-cdf\.zip/, "unzip " latest_ver ".zip")} 1' Dockerfile > Dockerfile.updated
+            mv Dockerfile.updated Dockerfile
+
+            echo is_up_to_date='' >> $GITHUB_OUTPUT
+          else
+            echo "CDF library is up to date."
+            echo is_up_to_date='$PARSED_LATEST_VERSION' >> $GITHUB_OUTPUT
+          fi
+
+          # Download and extract the latest CDF library
+          wget "${URL}${LATEST_VERSION}"
+          tar zxvpf "$LATEST_VERSION" && rm "$LATEST_VERSION"
+      
+      - name: Install dependencies for Building CDF library
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        run: sudo apt-get update && sudo apt-get -y install gfortran libncurses5-dev
+
+      - name: Build CDF library
+        id : build_cdf
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        run: |
+          FILENAME="${{ steps.check_latest_version.outputs.latest_version }}"
+      
+          # Assuming the extracted folder has the same name as the tar.gz file without the extension
+          FOLDER_NAME="${FILENAME%-cdf.tar.gz}"
+          ls
+          cd "$FOLDER_NAME"
+          make OS=linux ENV=gnu all
+          echo "CDF library built successfully."
+          echo folder_name=$FOLDER_NAME >> $GITHUB_OUTPUT
+
+      - name: Install CDF library
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        run: |
+            FOLDER_NAME="${{ steps.build_cdf.outputs.folder_name }}"
+
+            cd "$FOLDER_NAME"
+            sudo make INSTALLDIR=./cdf install
+
+      - name: Zip CDF Library in home
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        run: |
+              FOLDER_NAME="${{ steps.build_cdf.outputs.folder_name }}"
+
+              cd "$FOLDER_NAME"
+              zip -r latest.zip cdf
+    
+      - name: Upload CDF Library to GitHub Artifacts
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        uses: actions/upload-artifact@v2
+        with:
+          name: cdf
+          path: "${{ steps.build_cdf.outputs.folder_name }}/latest.zip"
+          
+      - name: Configure AWS Credentials For GitHub Actions
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload CDF Library to S3
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        run: |
+          S3_BUCKET_NAME="${{ secrets.AWS_S3_BUCKET_NAME }}"
+          FILENAME="${{ steps.build_cdf.outputs.folder_name }}/latest.zip"
+          LATEST_VERSION="${{ steps.check_latest_version.outputs.latest_version }}"
+          PARSED_LATEST_VERSION="${LATEST_VERSION%.tar.gz}"
+
+          aws s3 cp $FILENAME s3://$S3_BUCKET_NAME/cdf-binaries/latest.zip
+          aws s3 cp $FILENAME s3://$S3_BUCKET_NAME/cdf-binaries/$PARSED_LATEST_VERSION.zip
+      
+      - name: Create Pull Request
+        if: steps.check_maintainer.outputs.is_maintainer != '' && steps.check_latest_version.outputs.is_up_to_date == '' # Only run this step if the user is a maintainer and the CDF library is not up to date
+        uses: peter-evans/create-pull-request@v5.0.2
+        with:
+          title: 'Update CDF library to latest version (${{ steps.check_latest_version.outputs.latest_version }})'
+          body: '**Note: Close and Re-Open Pull Request to Run Workflow Tests.** Updates CDF library to latest version (${{ steps.check_latest_version.outputs.latest_version }})'
+          draft: true

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ coverage.xml
 .pytest_cache/
 cover/
 
+*-dist/
+
 # Sphinx documentation
 docs/_build/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ RUN apt-get update && \
     apt-get -y install --no-install-recommends -y python3-pip pylint git wget unzip&& \
     ln -s /usr/bin/python3 /usr/bin/python
 
-# Download Pre-Built CDF Binaries - Version: cdf38_0-dist-cdf
-RUN wget https://sdc-aws-support.s3.amazonaws.com/cdf-binaries/cdf38_0-dist-cdf.zip
+# Download Pre-Built CDF Binaries - Version: cdf39_0-dist-cdf
+RUN wget https://sdc-aws-support.s3.amazonaws.com/cdf-binaries/cdf39_0-dist-cdf.zip
 
 # Unzip CDF Binaries and move to /usr/local/cdf
-RUN unzip cdf38_0-dist-cdf.zip && mv cdf /usr/local/
+RUN unzip cdf39_0-dist-cdf.zip && mv cdf /usr/local/
 
 # add cdf binaries to the path
 ENV CDF_LIB="/usr/local/cdf/lib"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,22 @@
 # Image: Ubuntu 20.04 Stable, Official Image from Canonical
-FROM public.ecr.aws/lts/ubuntu:20.04_stable
+FROM public.ecr.aws/lts/ubuntu:22.04_stable
 
-# Performs updates and installs git, make, curl, python3.8, python3-pip, python3.8-dev and pylint packages
+# Performs updates and installs git, unzip, python3.8, python3-pip, python3.8-dev and pylint packages
 # Line 13 is required by the spacepy Python package
-# Line >=14 installs cdflib
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install --no-install-recommends -y python3.8 python3-pip python3.8-dev pylint && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    apt-get -y install git && \
-    apt-get -y install make && \
-    apt-get -y install curl && \
-    apt-get -y install wget && \
-    apt-get -y install gfortran && \
-    wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf39_0/linux/cdf39_0-dist-cdf.tar.gz && \
-    tar zxvpf cdf39_0-dist-cdf.tar.gz && rm cdf39_0-dist-cdf.tar.gz && \
-    apt-get -y install libncurses5-dev && \
-    apt-get -y install gcc && \
-    cd cdf39_0-dist && \
-    make OS=linux ENV=gnu all && \
-    make INSTALLDIR=/usr/local/cdf install && \
-    cd ..
+    apt-get -y install --no-install-recommends -y python3-pip pylint git wget unzip&& \
+    ln -s /usr/bin/python3 /usr/bin/python
+
+# Download Pre-Built CDF Binaries - Version: cdf38_0-dist-cdf
+RUN wget https://sdc-aws-support.s3.amazonaws.com/cdf-binaries/cdf38_0-dist-cdf.zip
+
+# Unzip CDF Binaries and move to /usr/local/cdf
+RUN unzip cdf38_0-dist-cdf.zip && mv cdf /usr/local/
 
 # add cdf binaries to the path
+ENV CDF_LIB="/usr/local/cdf/lib"
+
 ENV PATH="${PATH}:/usr/local/cdf/bin"
 
 # Copy Python requirements.txt file into image (list of common dependencies)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To make a change to this container image, please `fork` this repo, make the requ
 If you experience any issues in your development environment (`.devcontainer` environment on VSCode) when pulling this image from ECR, ensure you have the latest build by rebuilding your container to pull from latest.
 
 ## Dockerfile Details
-This Docker image is built from the official Canonical Ubuntu 20.04 image. It updates the system and installs necessary packages such as git, unzip, python3.8, python3-pip, and pylint. 
+This Docker image is built from the official Canonical Ubuntu 22.04 image. It updates the system and installs necessary packages such as git, unzip, python3.8, python3-pip, and pylint. 
 
 This Dockerfile also includes a process to download pre-built CDF binaries for data format support and copies a Python requirements.txt file into the image to be used for installing Python dependencies. 
 

--- a/README.md
+++ b/README.md
@@ -11,38 +11,40 @@ This repository is to define the image to be used for the development environmen
 
 This container is built and pushed to the public repo ECR automatically by AWS Codebuild.
 
-### **Base Image**: Ubuntu 20.04 ([public.ecr.aws/lts/ubuntu:20.04_stable](https://gallery.ecr.aws/lts/ubuntu))
+### **Base Image**: Ubuntu 22.04 ([public.ecr.aws/lts/ubuntu:22.04_stable](https://gallery.ecr.aws/lts/ubuntu))
 
 ### **ECR Repo:** Docker Lambda Base Image ([public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest](https://gallery.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base))
 
-### **Included OS Packages:**
+## Included OS Packages
 - git
-- make
-- curl
+- wget
+- unzip
 - python3.8
 - python3-pip
-- python3.8-dev
 - pylint
 
-### **Included Python Packages:**
-- numpy (v1.16.0)
-- astropy (v4.1.0)
-- awslambdaric (For use with interfacing with aws lambda)
-- sunpy
-- flake8 (For code style)
-- black (For code style)
-- tox
-- pytest (For testing)
-- pytest-astropy (For testing)
-- pytest-cov (For testing)
-- pre-commit
-- sphinx (For documentation)
-- sphinx-automodapi (For documentation)
-- sphinx-changelog (for changelog in documentation)
-- towncrier (For building changelog for documentation)
-- ipython (For easier debugging)
-- hermes core (For intrument packages)
-- boto3 (For AWS SDK)
+## Included Python Packages
+- numpy (v1.24.4)
+- astropy (v5.2.2)
+- sunpy (v4.1.7)
+- flake8 (v6.0.0) (For code style)
+- black (v23.7.0) (For code style)
+- pytest (v7.4.0) (For testing)
+- pytest-astropy (v0.10.0) (For testing)
+- pytest-cov (v4.1.0) (For testing)
+- pre-commit (v3.3.3)
+- sphinx (v6.2.1) (For documentation)
+- sphinx-automodapi (v0.15.0) (For documentation)
+- sphinx-changelog (v1.3.0) (For documentation)
+- ipython (v8.12.2) (For easier debugging)
+- hermes core (For instrument packages)
+- boto3 (v1.28.4) (For AWS SDK)
+- awslambdaric (v2.0.4) (For use with interfacing with AWS Lambda)
+- matplotlib (v3.7.2)
+- scipy (v1.10.1)
+- spacepy (v0.4.1) (For CDF file support)
+- ipykernel (v6.24.0) (For Jupyter notebook)
+- ccsdspy (For parsing CCSDS binary files)
 
 ### **Tests:**
 Checks whether the container contains the specified OS and Python requirements using the Container Structure Test ([CST testing suite](https://github.com/GoogleContainerTools/container-structure-test)). 
@@ -52,3 +54,13 @@ To make a change to this container image, please `fork` this repo, make the requ
 
 ### **Development Environment Troubleshooting:**
 If you experience any issues in your development environment (`.devcontainer` environment on VSCode) when pulling this image from ECR, ensure you have the latest build by rebuilding your container to pull from latest.
+
+## Dockerfile Details
+This Docker image is built from the official Canonical Ubuntu 20.04 image. It updates the system and installs necessary packages such as git, unzip, python3.8, python3-pip, and pylint. 
+
+This Dockerfile also includes a process to download pre-built CDF binaries for data format support and copies a Python requirements.txt file into the image to be used for installing Python dependencies. 
+
+Furthermore, it contains a test script to check if the container includes the specified OS and Python requirements using the Container Structure Test. 
+
+The Dockerfile finally creates a user 'vscode' with sudo support to run the container.
+

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,6 +33,7 @@ phases:
         echo Building the Docker image...          
         docker build -t ${IMAGE_NAME}:${ENVIRONMENT}-${GIT_TAG} .
         docker tag ${IMAGE_NAME}:${ENVIRONMENT}-${GIT_TAG} public.ecr.aws/w5r9l1c8/${IMAGE_NAME}:${ENVIRONMENT}-${GIT_TAG}
+        docker tag ${IMAGE_NAME}:${ENVIRONMENT}-${GIT_TAG} public.ecr.aws/w5r9l1c8/${IMAGE_NAME}:latest
         curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 && chmod +x container-structure-test-linux-amd64 && sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
         sudo yum install python3-pip -y
         sudo yum install make graphviz -y
@@ -42,6 +43,7 @@ phases:
         container-structure-test test --image ${IMAGE_NAME}:${ENVIRONMENT}-${GIT_TAG} --config cst_config.yaml
         echo Pushing the Docker image...
         docker push public.ecr.aws/w5r9l1c8/${IMAGE_NAME}:${ENVIRONMENT}-${GIT_TAG}
+        docker push public.ecr.aws/w5r9l1c8/${IMAGE_NAME}:latest
         PUBLIC_ECR_REPO=public.ecr.aws/w5r9l1c8/${IMAGE_NAME}:${ENVIRONMENT}-${GIT_TAG}
         echo Starting aws_processing_lambda CodeBuild project...
         aws codebuild start-build --project-name build_sdc_aws_processing_lambda \

--- a/cst_config.yaml
+++ b/cst_config.yaml
@@ -12,21 +12,6 @@ commandTests:
   args: ['-s','git']
   excludedError: ['.*FAIL.*']
   expectedOutput: ['.*install ok installed.*']
-- name: 'make'
-  command: 'dpkg'
-  args: ['-s','make']
-  excludedError: ['.*FAIL.*']
-  expectedOutput: ['.*install ok installed.*']
-- name: 'curl'
-  command: 'dpkg'
-  args: ['-s','curl']
-  excludedError: ['.*FAIL.*']
-  expectedOutput: ['.*install ok installed.*']
-- name: 'python3.8'
-  command: 'dpkg'
-  args: ['-s','python3.8']
-  excludedError: ['.*FAIL.*']
-  expectedOutput: ['.*install ok installed.*']
 - name: 'pylint'
   command: 'dpkg'
   args: ['-s','pylint']
@@ -40,7 +25,7 @@ commandTests:
 - name: 'python'
   command: 'python'
   args: ['--version']
-  expectedOutput: ['.*Python 3.8.*']
+  expectedOutput: ['.*Python 3.*']
 - name: 'python3'
   command: 'python3'
   args: ['container-tests/check_installed_py_packages.py']

--- a/cst_config.yaml
+++ b/cst_config.yaml
@@ -40,7 +40,7 @@ commandTests:
 - name: 'cdfinquire'
   command: 'cdfinquire'
   args: ['-id']
-  expectedOutput: ['.*CDF distribution V3.9.0_0.*']
+  expectedOutput: ['.*CDF distribution V*']
 
 
 # Test if needed files exist


### PR DESCRIPTION
This PR closes: https://github.com/HERMES-SOC/sdc_aws_base_docker_image/issues/32

It adds a new workflow triggered manually to build and update the CDF Binaries. It also cleans up the Dockerfile to remove the CDF library builds and pull the built binaries from our S3 bucket. 

The Workflow builds the latest cdf binaries and uploads them to S3, then generates a draft PR that updates the version on the Dockerfile of the Built CDF binaries.

This PR also updates the Base Docker image Ubuntu version from 20.04 to 22.04, which includes the proper GCLIB version required for the CDF Binaries to be run without being built directly. It also cleans up the CST config file to remove the packages that no longer exist. It also updates the README of the repo to reflect the changes. 

**Testing:**
It's a bit difficult to test the workflow until it's in place since it's manually triggered, but I've tried it on my fork. You can test the Dockerfile by building it locally.
