### PR TITLE
Add schedule runs and on-demand runs to workflows

### DIFF
--- a/.github/workflows/container-image-testing.yml
+++ b/.github/workflows/container-image-testing.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: # For on demand runs
+  schedule:
+    - cron: 0 0 * * * # Scheduled run every day at midnight
 
 jobs:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: # For on demand runs
+  schedule:
+    - cron: 0 0 * * * # Scheduled run every day at midnight
 jobs:
   build:
 
@@ -16,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-22.04]
-        python-version: [3.8]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.24.4
-astropy==5.2.2
-sunpy==4.1.7 # not currently needed
+astropy==5.3.3
+sunpy==5.0.1 # not currently needed
 ndcube==2.1.3 # Adding NDCube to support spectra and high-dimensional data in hermes_core data container
 flake8==6.0.0 # for code style
 black==23.7.0 # for code style


### PR DESCRIPTION
In our ongoing efforts to maintain the highest quality in our codebase, this PR introduces two significant enhancements to our

Scheduled Runs: Our pipelines will now run daily at midnight. This will keep our pipelines fresh and ensure that any external changes, such as updates to our dependencies, don't cause bugs.

On-Demand Runs: Developers can manually trigger the CI/CD process via the GitHub Actions tab if they need immediate verification of the CI/CD pipeline works without pushing a commit or waiting for a daily check

Also bumps python package version to match hermes_core