### PR TITLE
Lint with new version of black. Update packages. Fix deprecated devcontainer json. Add Ignore MacOS Hidden Files.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,55 +1,72 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/python-3
 {
-	"name": "Lambda Base Image Docker File",
-	"build": {
-		"dockerfile": "../Dockerfile",
-		"context": ".."
+	"name": "Ubuntu 20.04 Python 3",
+	// Repo where this image's Dockerfile is maintained: https://github.com/HERMES-SOC/docker-lambda-base
+	"image": "public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
+	"initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
+	// If you want to run the production version of the container, comment out the image and initializeCommand lines above and uncomment the line below.
+	// "image": "public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
+	// "initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"python.pythonPath": "/usr/bin/python3",
+				"python.testing.unittestEnabled": false,
+				"python.testing.pytestEnabled": true,
+				"python.languageServer": "Pylance",
+				
+				//PyLint Settings
+				"pylint.enabled": true,
+				"pylint.path": ["/usr/bin/pylint"],
+				"pylint.lintOnChange": true,
+				
+				// Black Settings
+				"python.editor.defaultFormatter": "ms-python.black-formatter",
+    			"python.editor.formatOnSave": true,
+				"black-formatter.path": ["/usr/local/bin/black"],
+				"black-formatter.args": [
+					"--line-length",
+					"100"
+				],
+
+				// Flake8 Settings
+				"flake8.path": ["/usr/local/bin/flake8"],
+				"flake8.lintOnChange": true,
+				
+				// Terminal Settings
+				"terminal.integrated.defaultProfile.linux": "bash (login)",
+				"terminal.integrated.profiles.linux": {
+					"bash (login)": {
+						"path": "bash"
+					}
+				}
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.pylint",
+				"ms-python.black-formatter",
+				"ms-python.flake8",
+				"marklarah.pre-commit-vscode",
+				"ms-toolsai.jupyter",
+				"ms-toolsai.jupyter-renderers",
+				"ms-toolsai.jupyter-keymap",
+				"jithurjacob.nbpreviewer"
+			],
+		}	
 	},
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"python.pythonPath": "/usr/bin/python3",
-		"python.languageServer": "Pylance",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.formatting.blackPath": "/usr/local/bin/black",
-		"python.formatting.provider": "black",
-		"python.formatting.blackArgs": [
-			"--line-length",
-			"100"
-		],
-		"python.testing.unittestEnabled": false,
-		"python.testing.pytestEnabled": true,
-		"python.linting.lintOnSave": true,
-		"python.linting.flake8Enabled": true,
-		"editor.formatOnSave": true,
-		"python.linting.banditPath": "/usr/local/bin/bandit",
-		"python.linting.flake8Path": "/usr/local/bin/flake8",
-		"python.linting.mypyPath": "/usr/local/bin/mypy",
-		"python.linting.pycodestylePath": "/usr/local/bin/pycodestyle",
-		"python.linting.pydocstylePath": "/usr/local/bin/pydocstyle",
-		"python.linting.pylintPath": "/usr/bin/pylint",
-		"terminal.integrated.defaultProfile.linux": "bash (login)",
-		"terminal.integrated.profiles.linux": {
-			"bash (login)": {
-				"path": "bash"
-			}
-		}
-	},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"marklarah.pre-commit-vscode",
-		"ms-toolsai.jupyter",
-		"ms-toolsai.jupyter-renderers",
-		"ms-toolsai.jupyter-keymap",
-		"jithurjacob.nbpreviewer"
-	],
+
 	// Mount to a volume if you'd like to persist data to your disk
-	// "mounts": ["source=<add your /path/on/host here>, target=/workspaces/hermes_core, type=bind"],
+	"mounts": [
+		"source=${localEnv:HOME}/.bash_profile,target=/home/vscode/.bashrc,type=bind,consistency=cached"
+	],
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
+	
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/README.md
+++ b/README.md
@@ -24,26 +24,26 @@ This container is built and pushed to the public repo ECR automatically by AWS C
 - pylint
 
 ## Included Python Packages
-- numpy (v1.24.4)
-- astropy (v5.2.2)
-- sunpy (v4.1.7)
-- flake8 (v6.0.0) (For code style)
-- black (v23.7.0) (For code style)
-- pytest (v7.4.0) (For testing)
-- pytest-astropy (v0.10.0) (For testing)
-- pytest-cov (v4.1.0) (For testing)
-- pre-commit (v3.3.3)
-- sphinx (v6.2.1) (For documentation)
-- sphinx-automodapi (v0.15.0) (For documentation)
-- sphinx-changelog (v1.3.0) (For documentation)
-- ipython (v8.12.2) (For easier debugging)
+- numpy 
+- astropy 
+- sunpy 
+- flake8 (For code style)
+- black (For code style)
+- pytest (For testing)
+- pytest-astropy(For testing)
+- pytest-cov (For testing)
+- pre-commit
+- sphinx (For documentation)
+- sphinx-automodapi (For documentation)
+- sphinx-changelog (For documentation)
+- ipython (For easier debugging)
 - hermes core (For instrument packages)
-- boto3 (v1.28.4) (For AWS SDK)
-- awslambdaric (v2.0.4) (For use with interfacing with AWS Lambda)
-- matplotlib (v3.7.2)
-- scipy (v1.10.1)
-- spacepy (v0.4.1) (For CDF file support)
-- ipykernel (v6.24.0) (For Jupyter notebook)
+- boto3 (For AWS SDK)
+- awslambdaric (For use with interfacing with AWS Lambda)
+- matplotlib
+- scipy
+- spacepy (For CDF file support)
+- ipykernel (For Jupyter notebook)
 - ccsdspy (For parsing CCSDS binary files)
 
 ### **Tests:**

--- a/container-tests/check_installed_py_packages.py
+++ b/container-tests/check_installed_py_packages.py
@@ -19,7 +19,7 @@ with pathlib.Path("/requirements.txt").open() as requirements_txt:
             package_name = str(package).split("==")[0].split("@")[0].replace("-", "_")
         else:
             package_name = str(package).split(">=")[0].split("@")[0].replace("-", "_")
-            
+
         if package_name not in EXCEPTION_LIST:
             spec = importlib.util.find_spec(package_name)
             if spec is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,25 @@
-numpy==1.24.4
+numpy==1.26.3
 astropy==5.3.3
 sunpy==5.0.1 # not currently needed
 ndcube==2.1.3 # Adding NDCube to support spectra and high-dimensional data in hermes_core data container
-flake8==6.0.0 # for code style
-black==23.7.0 # for code style
+flake8==7.0.0 # for code style
+black==24.1.1 # for code style
 pytest==7.4.0 # for testing
 pytest-astropy==0.10.0 # for testing helpers
 pytest-cov==4.1.0 # for testing coverage
 pre-commit==3.3.3 # for pre-commit checks
 setuptools_scm==6.3.2 # for version number
-sphinx==6.2.1 # for documentation
-sphinx-automodapi==0.15.0 # for documentation
+sphinx==7.2.6 # for documentation
+sphinx-automodapi==0.16.0 # for documentation
 sphinx-copybutton==0.5.2 # for documentation
 sphinx-changelog==1.3.0 # for changelog in documentation
 sphinx_rtd_theme==1.2.2 # for documentation
 ipython==8.12.2 # for easier debugging
 hermes_core @ git+https://github.com/HERMES-SOC/hermes_core.git # for hermes instrument packages
-boto3==1.28.4 # for aws sdk
+boto3==1.34.34 # for aws sdk
 awslambdaric==2.0.4 # for use with interfacing with aws lambda
 matplotlib==3.7.2 # required by spacepy but best to explicitly install it
 scipy==1.10.1 # required by spacepy but best to explicitly install it
 spacepy==0.4.1 # for cdf file support
-ipykernel==6.24.0 # for jupyter notebook
+ipykernel==6.29.0 # for jupyter notebook
 ccsdspy @ git+https://github.com/ddasilva/ccsdspy.git # for parsing ccsds binary files


### PR DESCRIPTION
This PR does the following:
- lints the python script with the new version of black
- updates the version pinning in the requirements file to the newer versions
- updates the devcontainer to remove the the deprecated linting options
- Adds the hidden files to the .gitignore