### PR TITLE
Fix requirements file needing to be defined in readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,11 @@ build:
   tools:
     python: "3.10"
 
+# Set which requirements should be installed
+python:
+  install:
+    - requirements: requirements.txt 
+
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - pdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ sphinx-copybutton==0.5.2 # for documentation
 sphinx-changelog==1.3.0 # for changelog in documentation
 sphinx_rtd_theme==2.0.0 # for documentation
 ipython==8.12.2 # for easier debugging
-swxsoc @ git+https://github.com/swxsoc/swxsoc.git@main # for interfacing with the SWxSOC API
+swxsoc @ git+https://github.com/swxsoc/swxsoc.git # for interfacing with the SWxSOC API
 hermes_core @ git+https://github.com/HERMES-SOC/hermes_core.git # for hermes instrument packages
 boto3==1.34.34 # for aws sdk
 awslambdaric==2.0.4 # for use with interfacing with aws lambda

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ sphinx-changelog==1.3.0 # for changelog in documentation
 sphinx_rtd_theme==2.0.0 # for documentation
 ipython==8.12.2 # for easier debugging
 hermes_core @ git+https://github.com/HERMES-SOC/hermes_core.git # for hermes instrument packages
+swxsoc @ git+https://github.com/swxsoc/swxsoc.git@main # for interfacing with the SWxSOC API
 boto3==1.34.34 # for aws sdk
 awslambdaric==2.0.4 # for use with interfacing with aws lambda
 matplotlib==3.7.2 # required by spacepy but best to explicitly install it

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ sphinx-copybutton==0.5.2 # for documentation
 sphinx-changelog==1.3.0 # for changelog in documentation
 sphinx_rtd_theme==2.0.0 # for documentation
 ipython==8.12.2 # for easier debugging
-swxsoc @ git+https://github.com/swxsoc/swxsoc.git # for interfacing with the SWxSOC API
 hermes_core @ git+https://github.com/HERMES-SOC/hermes_core.git # for hermes instrument packages
 boto3==1.34.34 # for aws sdk
 awslambdaric==2.0.4 # for use with interfacing with aws lambda

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,8 @@ sphinx-copybutton==0.5.2 # for documentation
 sphinx-changelog==1.3.0 # for changelog in documentation
 sphinx_rtd_theme==2.0.0 # for documentation
 ipython==8.12.2 # for easier debugging
-hermes_core @ git+https://github.com/HERMES-SOC/hermes_core.git # for hermes instrument packages
 swxsoc @ git+https://github.com/swxsoc/swxsoc.git@main # for interfacing with the SWxSOC API
+hermes_core @ git+https://github.com/HERMES-SOC/hermes_core.git # for hermes instrument packages
 boto3==1.34.34 # for aws sdk
 awslambdaric==2.0.4 # for use with interfacing with aws lambda
 matplotlib==3.7.2 # required by spacepy but best to explicitly install it


### PR DESCRIPTION
Readthedocs made some change recently that apperently required you to define what requirements need to be installed in the yaml file. I have added the changes needed for them to build properly.